### PR TITLE
Change install instructions to use a helm repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,16 @@
-on: [push, release]
+on: [release]
 name: 'Publish Docker Images'
 jobs:
+  helmRelease:
+    name: 'Package Helm Chart'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: J12934/helm-gh-pages-action@v1.0.0
+        with:
+          access-token: ${{ secrets.ACCESS_TOKEN }}
+          charts-folder: helm
+          deploy-branch: gh-pages
   progressWatchDog:
     name: ProgressWatchDog
     runs-on: ubuntu-latest

--- a/guides/aws/aws.md
+++ b/guides/aws/aws.md
@@ -34,15 +34,14 @@ kubectl config current-context
 ## Step 2. Installing JuicyCTF via helm
 
 ```sh
-# We'll need to clone this git repo for the moment, as the helm chart isn't pushed to any registry
-git clone git@github.com:iteratec/juicy-ctf.git
+# You'll need to add the juicy-ctf helm repo to your helm repos
+helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# First we'll need to fetch the charts JuicyCTF depends on
-helm dependency update ./juicy-ctf/helm/juicy-ctf/
+# for helm 2
+helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# Now we can install the helm chart
-# The first juicy-ctf part is the release name, safe to change to whatever you like, but the examples in the guide are written for 'juicy-ctf'
-helm install juicy-ctf ./juicy-ctf/helm/juicy-ctf/
+# for helm 3
+helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:
@@ -86,7 +85,8 @@ After you have set that up we can now create a ingress config for our the JuicyC
 
 ```sh
 # create the ingress for the JuiceBalancer service
-kubectl apply -f juicy-ctf/examples/aws/aws-ingress.yaml
+wget https://raw.githubusercontent.com/iteratec/juicy-ctf/master/guides/aws/aws-ingress.yaml
+kubectl apply -f aws-ingress.yaml
 ```
 
 ## Step 5. Deinstallation
@@ -99,7 +99,7 @@ helm delete juicy-ctf
 kubectl delete persistentvolumeclaims redis-data-juicy-ctf-redis-master-0 redis-data-juicy-ctf-redis-slave-0
 
 # Delete the loadbalancer
-kubectl delete -f juicy-ctf/examples/aws/aws-ingress.yaml
+kubectl delete -f aws-ingress.yaml
 
 # Delete the kubernetes cluster
 eksctl delete cluster juicy-ctf

--- a/guides/aws/aws.md
+++ b/guides/aws/aws.md
@@ -37,10 +37,10 @@ kubectl config current-context
 # You'll need to add the juicy-ctf helm repo to your helm repos
 helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# for helm 2
+# for helm <= 2
 helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# for helm 3
+# for helm >= 3
 helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods

--- a/guides/azure/azure.md
+++ b/guides/azure/azure.md
@@ -29,10 +29,10 @@ kubectl config current-context
 # You'll need to add the juicy-ctf helm repo to your helm repos
 helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# for helm 2
+# for helm <= 2
 helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# for helm 3
+# for helm >= 3
 helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods

--- a/guides/azure/azure.md
+++ b/guides/azure/azure.md
@@ -26,15 +26,14 @@ kubectl config current-context
 ## Step 2. Installing JuicyCTF via helm
 
 ```bash
-# We'll need to clone this git repo for the moment, as the helm chart isn't pushed to any registry
-git clone git@github.com:iteratec/juicy-ctf.git
+# You'll need to add the juicy-ctf helm repo to your helm repos
+helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# First we'll need to fetch the charts JuicyCTF depends on
-helm dependency update ./juicy-ctf/helm/juicy-ctf/
+# for helm 2
+helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# Now we can install the helm chart
-# The first juicy-ctf part is the release name, safe to change to whatever you like, but the examples in the guide are written for 'juicy-ctf'
-helm install juicy-ctf ./juicy-ctf/helm/juicy-ctf/
+# for helm 3
+helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:

--- a/guides/digital-ocean/digital-ocean.md
+++ b/guides/digital-ocean/digital-ocean.md
@@ -29,10 +29,10 @@ kubectl config current-context
 # You'll need to add the juicy-ctf helm repo to your helm repos
 helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# for helm 2
+# for helm <= 2
 helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# for helm 3
+# for helm >= 3
 helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods

--- a/guides/digital-ocean/digital-ocean.md
+++ b/guides/digital-ocean/digital-ocean.md
@@ -26,15 +26,14 @@ kubectl config current-context
 ## Step 2. Installing JuicyCTF via helm
 
 ```bash
-# We'll need to clone this git repo for the moment, as the helm chart isn't pushed to any registry
-git clone git@github.com:iteratec/juicy-ctf.git
+# You'll need to add the juicy-ctf helm repo to your helm repos
+helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# First we'll need to fetch the charts JuicyCTF depends on
-helm dependency update ./juicy-ctf/helm/juicy-ctf/
+# for helm 2
+helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# Now we can install the helm chart
-# The first juicy-ctf part is the release name, safe to change to whatever you like, but the examples in the guide are written for 'juicy-ctf'
-helm install juicy-ctf ./juicy-ctf/helm/juicy-ctf/
+# for helm 3
+helm install juicy-ctf juicy-ctf/juicy-ctf
 
 # kubernetes will now spin up the pods
 # to verify every thing is starting up, run:
@@ -77,11 +76,12 @@ doctl compute certificate list
 
 # We got a example loadbalancer yaml for this example in the repository
 # Edit the cert id in do-lb.yaml to the cert id of your domain
-vim juicy-ctf/example/digital-ocean/do-lb.yaml
+wget https://raw.githubusercontent.com/iteratec/juicy-ctf/master/guides/digital-ocean/do-lb.yaml
+vim do-lb.yaml
 
 # Create the loadbalancer
 # This might take a couple of minutes
-kubectl create -f juicy-ctf/example/digital-ocean/do-lb.yaml
+kubectl create -f do-lb.yaml
 
 # If it takes longer than a few minutes take a detailed look at the loadbalancer
 kubectl describe services juicy-ctf-loadbalancer
@@ -97,7 +97,7 @@ helm delete juicy-ctf
 kubectl delete persistentvolumeclaims redis-data-juicy-ctf-redis-master-0 redis-data-juicy-ctf-redis-slave-0
 
 # Delete the loadbalancer
-kubectl delete -f juicy-ctf/example/digital-ocean/do-lb.yaml
+kubectl delete -f do-lb.yaml
 
 # Delete the kubernetes cluster
 doctl kubernetes cluster delete juicy-k8s

--- a/guides/openshift/openshift.md
+++ b/guides/openshift/openshift.md
@@ -24,25 +24,18 @@ oc new-project juicy-ctf
 ## Step 2. Installing JuicyCTF via helm
 
 ```bash
-# We'll need to clone this git repo for the moment, as the helm chart isn't pushed to any registry
-git clone git@github.com:iteratec/juicy-ctf.git
-
-# First we'll need to fetch the charts JuicyCTF depends on
-helm dependency update ./juicy-ctf/helm/juicy-ctf/
+# You'll need to add the juicy-ctf helm repo to your helm repos
+helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
 # Before we can install the cluster we need to change one config option, which clashes with OpenShifts security context
 # For that download the OpenShift overrides config file
 wget https://raw.githubusercontent.com/iteratec/juicy-ctf/master/guides/openshift/openshift-helm-overrides.yaml
 
-# Now we can install the helm chart
-# The first juicy-ctf part is the release name, safe to change to whatever you like, but the examples in the guide are written for 'juicy-ctf'
-helm install juicy-ctf -f openshift-helm-overrides.yaml ./juicy-ctf/helm/juicy-ctf/
+# for helm 2
+helm install juicy-ctf/juicy-ctf --name juicy-ctf -f openshift-helm-overrides.yaml ./juicy-ctf/helm/juicy-ctf/
 
-# kubernetes will now spin up the pods
-# to verify every thing is starting up, run:
-kubectl get pods
-# This should show you three pods a juice-balancer pod and two redis pods
-# Wait until all 3 pods are ready
+# for helm 3
+helm install juicy-ctf juicy-ctf/juicy-ctf -f openshift-helm-overrides.yaml ./juicy-ctf/helm/juicy-ctf/
 ```
 
 ## Step 3. Verify the app is running correctly

--- a/guides/openshift/openshift.md
+++ b/guides/openshift/openshift.md
@@ -31,10 +31,10 @@ helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 # For that download the OpenShift overrides config file
 wget https://raw.githubusercontent.com/iteratec/juicy-ctf/master/guides/openshift/openshift-helm-overrides.yaml
 
-# for helm 2
+# for helm <= 2
 helm install juicy-ctf/juicy-ctf --name juicy-ctf -f openshift-helm-overrides.yaml ./juicy-ctf/helm/juicy-ctf/
 
-# for helm 3
+# for helm >= 3
 helm install juicy-ctf juicy-ctf/juicy-ctf -f openshift-helm-overrides.yaml ./juicy-ctf/helm/juicy-ctf/
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,10 @@ It's easier to install and easier to use. It's pretty stable, and it doesn't hav
 ```sh
 helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# helm 2
+# for helm <= 2
 helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# helm 3
+# for helm >= 3
 helm install juicy-ctf juicy-ctf/juicy-ctf
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -22,14 +22,13 @@ If you aren't familiar with helm, try out the helm 3 beta.
 It's easier to install and easier to use. It's pretty stable, and it doesn't have a server side component anymore. It just runs on your local machine.
 
 ```sh
-git clone git@github.com:iteratec/juicy-ctf.git
+helm repo add juicy-ctf https://iteratec.github.io/juicy-ctf/
 
-# First we'll need to fetch the charts JuicyCTF depends on
-helm dependency update ./juicy-ctf/helm/juicy-ctf/
+# helm 2
+helm install juicy-ctf/juicy-ctf --name juicy-ctf
 
-# Now we can install the helm chart
-# The first juicy-ctf part is the release name, safe to change to whatever you like.
-helm install juicy-ctf ./juicy-ctf/helm/juicy-ctf/
+# helm 3
+helm install juicy-ctf juicy-ctf/juicy-ctf
 ```
 
 ### Installation Guides for specific Cloud Providers


### PR DESCRIPTION
The helm release was previously installed via a locally cloned repo.

Now JuicyCTF hosts a helm repository using GitHub Pages to make installation easier, for that the build process has been updated to package and publish new versions of JuicyCTF to the helm repository. Also the install instructions have been updated to instruct users to install JuicyCTF via the new helm repo.