### PR TITLE
Automatic cleanup of JuiceShop on uninstall

### DIFF
--- a/helm/juicy-ctf/templates/juice-balancer-deployment.yaml
+++ b/helm/juicy-ctf/templates/juice-balancer-deployment.yaml
@@ -51,6 +51,10 @@ spec:
                 secretKeyRef:
                   name: juice-balancer-secret
                   key: adminPassword
+            - name: BALANCER_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           volumeMounts:
             - name: config-volume
               mountPath: /home/app/config/

--- a/helm/juicy-ctf/templates/juice-balancer-deployment.yaml
+++ b/helm/juicy-ctf/templates/juice-balancer-deployment.yaml
@@ -51,10 +51,6 @@ spec:
                 secretKeyRef:
                   name: juice-balancer-secret
                   key: adminPassword
-            - name: BALANCER_UID
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.uid
           volumeMounts:
             - name: config-volume
               mountPath: /home/app/config/

--- a/readme.md
+++ b/readme.md
@@ -55,8 +55,6 @@ helm install -f values.yaml juicy-ctf ./juicy-ctf/helm/juicy-ctf/
 
 ```sh
 helm delete juicy-ctf
-# Also delete all Juice Shop Deployments which still exist
-kubectl delete deployment --selector app=juice-shop && kubectl delete service --selector app=juice-shop
 ```
 
 ## FAQ


### PR DESCRIPTION
JuiceShop Instances are now properly linked to the JuiceBalancer they were created by.
This is done by using the kubernetes ownerReferences: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/

When the Stack gets uninstalled all JuiceShop Instances and Services are automatically cleaned up by kubernetes.

This has the nice side effect that the awesome tool [kubectl-tree](https://github.com/ahmetb/kubectl-tree) now works properly:
<img width="842" alt="Screenshot 2020-01-08 at 14 49 01" src="https://user-images.githubusercontent.com/13718901/71982957-060eca00-3226-11ea-9bdc-656796c0c3c1.png">
